### PR TITLE
Update localhost API URL to use nginx proxy

### DIFF
--- a/WebApps/Shopping.React/src/services/api.js
+++ b/WebApps/Shopping.React/src/services/api.js
@@ -5,7 +5,7 @@ const API_BASE_URL =
   process.env.NODE_ENV === "production"
     ? "/api"
     : window.location.hostname === "localhost"
-      ? "http://localhost:6004"
+      ? "/api" // Use nginx proxy from localhost:6006/api
       : "http://yarpapigateway:8080";
 
 const api = axios.create({


### PR DESCRIPTION
Changed localhost API base URL from "http://localhost:6004" to "/api" to use nginx proxy from localhost:6006/api.

This updates the API configuration in the Shopping React web app to route localhost requests through the nginx proxy instead of directly to port 6004.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9a4c3022ec9b4b0eacbf6e01db31bdf7/flare-lab)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9a4c3022ec9b4b0eacbf6e01db31bdf7</projectId>-->
<!--<branchName>flare-lab</branchName>-->